### PR TITLE
Fix error: tools/install.sh: line 128: tools/config.bullseye: No such…

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -125,7 +125,7 @@ function import_config {
     [ "$(cut -d " " -f1 < /proc/device-tree/model)" == "Raspberry" ] &&
     [ -f "tools/config.rpi-bullseye" ]; then
         # shellcheck disable=SC1091
-        source tools/config.bullseye
+        source tools/config.rpi-bullseye
         return 0
     fi
 


### PR DESCRIPTION
… file or directory

This PR fixed the error I ran into:

```
pi@raspberrypi:~/crowsnest $ make install
tools/install.sh: line 128: tools/config.bullseye: No such file or directory
make: *** [Makefile:35: install] Error 1
```

OS: RPiOS bullseye. 32bit.
