### PR TITLE
Switch apt to apt-get with --quiet option to avoid the warning thrown by the current apt ... > /dev/null

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -276,7 +276,7 @@ function install_crowsnest {
     ## Install Dependencies
     echo -e "Installing 'crowsnest' Dependencies ..."
     # shellcheck disable=2086
-    sudo apt install --yes --no-install-recommends ${CROWSNEST_CROWSNEST_DEPS} > /dev/null
+    sudo apt-get install --quiet --yes --no-install-recommends ${CROWSNEST_CROWSNEST_DEPS}
     echo -e "Installing 'crowsnest' Dependencies ... [OK]"
     ## Link crowsnest to $PATH
     echo -en "Linking crowsnest ...\r"


### PR DESCRIPTION
Switch from `apt` to `apt-get` -- as `apt` is designed to be an interactive wrapper around `apt-get`.

This change will remove the current "WARNING: apt does not have a stable CLI interface. Use with caution in scripts." message.  

The `--quiet` option will "[Produce] output suitable for logging, omitting progress indicators." (source: https://linux.die.net/man/8/apt-get ).  

Per @Apexpredation in https://github.com/mainsail-crew/crowsnest/issues/41#issuecomment-1286914341 , apt's progress indicators can mess with scripts...and this is being run in a script.