### PR TITLE
Prefix V4L2 control skipped message

### DIFF
--- a/libs/v4l2_control.sh
+++ b/libs/v4l2_control.sh
@@ -43,7 +43,7 @@ function v4l2_control {
                     opt_avail="$(v4l2-ctl -d "${device}" -L | \
                     grep -c "${valueless}" || true)"
                     if [ "${opt_avail}" -eq "0" ]; then
-                        log_msg "Parameter '${param}' not available for '${device}'. Skipped."
+                        log_msg "Parameter '${param}' not available for '${device}'. V4L2 control skipped."
                     else
                         v4l2-ctl -d "${device}" -c "${param}" 2> /dev/null
                     fi
@@ -52,7 +52,7 @@ function v4l2_control {
                         v4l2-ctl -d "${device}" -L | log_output "v4l2ctl"
                     fi
             else
-                log_msg "No parameters set for [cam ${cam}]. Skipped."
+                log_msg "No parameters set for [cam ${cam}]. V4L2 control skipped."
             fi
         done
     }


### PR DESCRIPTION
Small usability improvement: change the "skipped" message that happens when V4L2 control isn't configured to "V4L2 control skipped".

I'm totally new to crowsnest and was pulling my hair out trying to figure out why my webcam wasn't working - and this "No parameters set for [cam 1]. Skipped." message had me thinking that somehow crowsnest was skipping using the camera in its entirety. It took me an embarrassingly long time to work out that that message had to do with V4L2 control only. Figured I'd save the next newbie from going down the same rabbit hole :)