### PR TITLE
docs: Update index with correct heading and link to backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A wrapper script for webcam streaming on Raspberry Pi OS Lite images like [Mains
 -   [Contribute](#contribute)
 -   [How to support us?](#how-to-support-us)
 -   [CustomPiOS-module](#custompios-module)
--   [What 'Backends' uses crowsnest?](#what-backends-uses-crowsnest)
+-   [What 'Backends' does crowsnest use](#what-backends-does-crowsnest-use)
 -   [Credits](#credits)
 
 ---


### PR DESCRIPTION
This is a follow-up to #108 and fixes heading and hyperlink to the list of backends