### PR TITLE
fix: Not adding --camera-format if it's already in custom_flags

### DIFF
--- a/libs/camera-streamer.sh
+++ b/libs/camera-streamer.sh
@@ -57,7 +57,8 @@ function run_ayucamstream() {
 
     # Use MJPEG Hardware encoder if possible
     if [ "$(detect_mjpeg "${cam_sec}")" = "1" ] &&
-    [[ ! "${dev}" =~ "/base/soc" ]]; then
+    [[ ! "${dev}" =~ "/base/soc" ]] &&
+    [[ ! "${cstm}" =~ "--camera-format=" ]]; then
         start_param+=( --camera-format=MJPG )
     fi
 


### PR DESCRIPTION
Maybe there is a more elegant way to handle this user case. But it seems that currently setting `custom_flags: --camera-format=YUYV` in "crowsnest.conf" will result in crowsnest not starting.