### PR TITLE
fix: update camera-streamer branch from master to main

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -39,10 +39,10 @@ fi
 # Camera-streamer repo
 CSTREAMER_PATH="camera-streamer"
 if [[ -z "${CROWSNEST_CAMERA_STREAMER_REPO_SHIP}" ]]; then
-    CROWSNEST_CAMERA_STREAMER_REPO_SHIP="https://github.com/ayufan-research/camera-streamer.git"
+    CROWSNEST_CAMERA_STREAMER_REPO_SHIP="https://github.com/ayufan/camera-streamer.git"
 fi
 if [[ -z "${CROWSNEST_CAMERA_STREAMER_REPO_BRANCH}" ]]; then
-    CROWSNEST_CAMERA_STREAMER_REPO_BRANCH="master"
+    CROWSNEST_CAMERA_STREAMER_REPO_BRANCH="main"
 fi
 
 

--- a/custompios/crowsnest/config
+++ b/custompios/crowsnest/config
@@ -28,7 +28,7 @@
 
 # camera-streamer
 [[ -n "$CROWSNEST_CAMERA_STREAMER_REPO_SHIP" ]] || CROWSNEST_CAMERA_STREAMER_REPO_SHIP="https://github.com/ayufan/camera-streamer.git"
-[[ -n "$CROWSNEST_CAMERA_STREAMER_REPO_BRANCH" ]] || CROWSNEST_CAMERA_STREAMER_REPO_BRANCH="master"
+[[ -n "$CROWSNEST_CAMERA_STREAMER_REPO_BRANCH" ]] || CROWSNEST_CAMERA_STREAMER_REPO_BRANCH="main"
 
 ###########################################################################
 ### DO NOT EDIT BELOW THIS LINE, UNLESS YOU KNOW EXACTLY WHAT HAPPENDS! ###

--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -28,8 +28,8 @@ CN_CONFIG_ROOTPATH="/home/${CN_CONFIG_USER}/printer_data"
 # CN_MOONRAKER_CONFIG_PATH="${CN_CONFIG_CONFIGPATH}/moonraker.conf"
 CN_USTREAMER_REPO="https://github.com/pikvm/ustreamer.git"
 CN_USTREAMER_BRANCH="master"
-CN_CAMERA_STREAMER_REPO="https://github.com/ayufan-research/camera-streamer.git"
-CN_CAMERA_STREAMER_BRANCH="master"
+CN_CAMERA_STREAMER_REPO="https://github.com/ayufan/camera-streamer.git"
+CN_CAMERA_STREAMER_BRANCH="main"
 
 ### Messages
 header_msg() {

--- a/tools/libs/config.sh
+++ b/tools/libs/config.sh
@@ -38,7 +38,7 @@ import_config() {
         [[ -n "${CROWSNEST_USTREAMER_REPO_SHIP}" ]] || CROWSNEST_USTREAMER_REPO_SHIP="https://github.com/pikvm/ustreamer.git"
         [[ -n "${CROWSNEST_USTREAMER_REPO_BRANCH}" ]] || CROWSNEST_USTREAMER_REPO_BRANCH="master"
         [[ -n "${CROWSNEST_CAMERA_STREAMER_REPO_SHIP}" ]] || CROWSNEST_CAMERA_STREAMER_REPO_SHIP="https://github.com/ayufan/camera-streamer.git"
-        [[ -n "${CROWSNEST_CAMERA_STREAMER_REPO_BRANCH}" ]] || CROWSNEST_CAMERA_STREAMER_REPO_BRANCH="master"
+        [[ -n "${CROWSNEST_CAMERA_STREAMER_REPO_BRANCH}" ]] || CROWSNEST_CAMERA_STREAMER_REPO_BRANCH="main"
         status_msg "Using default configuration ..." "0"
     fi
 }


### PR DESCRIPTION
https://github.com/ayufan/camera-streamer recently changed the default branch name from `master` to `main`. From the README:

> Use `main` branch for semi-stable changes, or `develop` for experimental changes.

The `master` branch is still present, but out-of-date, and missing features, such as being able to restrict the listening address.