### PR TITLE
fix: fix CustomPiOS docker build error

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -42,7 +42,7 @@ main() {
         exit 1
     fi
 
-    if [[ -z "${SUDO_USER}" ]]; then
+    if [[ -z "${SUDO_USER}" ]] && [[ "${CROWSNEST_UNATTENDED}" != "1" ]]; then
         need_sudo_msg
         exit 1
     fi


### PR DESCRIPTION
Fixes #141 
The CustomPiOS docker image doesn't have the `SUDO_USER` variable defined during the build process. This PR will skip the sudo privileges check for this specific case