### PR TITLE
fix: fix libcamera-apps-lite not getting updated

### DIFF
--- a/tools/libs/pkglist-rpi.sh
+++ b/tools/libs/pkglist-rpi.sh
@@ -22,5 +22,5 @@ PKGLIST="git crudini bsdutils findutils v4l-utils curl"
 ### Ustreamer Dependencies
 PKGLIST="${PKGLIST} build-essential libevent-dev libjpeg-dev libbsd-dev"
 ### Camera-Streamer Dependencies
-PKGLIST="${PKGLIST} cmake libavformat-dev libavutil-dev libavcodec-dev libcamera-dev"
+PKGLIST="${PKGLIST} cmake libavformat-dev libavutil-dev libavcodec-dev libcamera-dev libcamera-apps-lite"
 PKGLIST="${PKGLIST} liblivemedia-dev pkg-config xxd build-essential cmake libssl-dev"


### PR DESCRIPTION
`libcamera-apps-lite` is needed for `libcamera-hello`. Crowsnest uses `libcamera-hello` to detected raspicams