### PR TITLE
fix(hwhandler.sh): fix error in device logging (#169)

### DIFF
--- a/libs/hwhandler.sh
+++ b/libs/hwhandler.sh
@@ -69,8 +69,7 @@ detect_libcamera() {
         else
             echo "0"
         fi
-    fi
-    if [[ "$(is_raspberry_pi)" = "0" ]]; then
+    else
         echo "0"
     fi
 }

--- a/libs/logging.sh
+++ b/libs/logging.sh
@@ -90,17 +90,19 @@ function print_cfg {
 function print_cams {
     local total v4l
     v4l="$(find /dev/v4l/by-id/ -iname "*index0" 2> /dev/null | wc -l)"
-    total="$((v4l+($(detect_libcamera))+($(detect_legacy))))"
+    libcamera="$(detect_libcamera)"
+    legacy="$(detect_legacy)"
+    total="$((v4l+libcamera+legacy))"
     if [ "${total}" -eq 0 ]; then
         log_msg "ERROR: No usable Devices Found. Stopping $(basename "${0}")."
         exit 1
     else
         log_msg "INFO: Found ${total} total available Device(s)"
     fi
-    if [[ "$(detect_libcamera)" -ne 0 ]]; then
+    if [[ "${libcamera}" -ne 0 ]]; then
         log_msg "Detected 'libcamera' device -> $(get_libcamera_path)"
     fi
-    if [[ "$(detect_legacy)" -ne 0 ]]; then
+    if [[ "${legacy}" -ne 0 ]]; then
         raspicam="$(v4l2-ctl --list-devices |  grep -A1 -e 'mmal' | \
         awk 'NR==2 {print $1}')"
         log_msg "Detected 'Raspicam' Device -> ${raspicam}"


### PR DESCRIPTION
* fix(hwhandler.sh): fix error in device logging

If device is a Raspberry Pi and does not have libcamera-hello, it does not log devices

Error occurs in Line 93 of logging.sh



* fix: remove unnecessary double funtion calls
