### PR TITLE
fix: fix wrong gpumem calculation

### DIFF
--- a/tools/libs/set_gpumem.sh
+++ b/tools/libs/set_gpumem.sh
@@ -29,11 +29,9 @@ set_gpu_mem() {
     ## Determine Ramsize and export MAKEFLAG
     if [[ "$(get_avail_mem)" -le 524288 ]]; then
         mem_split=128
-    fi
-    if [[ "$(get_avail_mem)" -le 1048576 ]]; then
+    elif [[ "$(get_avail_mem)" -le 1048576 ]]; then
         mem_split=160
-    fi
-    if [[ "$(get_avail_mem)" -gt 1048576 ]]; then
+    else [[ "$(get_avail_mem)" -gt 1048576 ]]; then
         mem_split=256
     fi
     if [[ "$(is_raspbian)" = "1" ]] && [[ -n "$(command -v raspi-config)" ]]; then


### PR DESCRIPTION
On devices with less than 512MB existing devices will use `160` instead of `128` due to wrong condition.