### PR TITLE
fix: add bookworm support

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -39,7 +39,7 @@ fi
 # Camera-streamer repo
 CSTREAMER_PATH="camera-streamer"
 if [[ -z "${CROWSNEST_CAMERA_STREAMER_REPO_SHIP}" ]]; then
-    CROWSNEST_CAMERA_STREAMER_REPO_SHIP="https://github.com/ayufan-research/camera-streamer.git"
+    CROWSNEST_CAMERA_STREAMER_REPO_SHIP="https://github.com/ayufan/camera-streamer.git"
 fi
 if [[ -z "${CROWSNEST_CAMERA_STREAMER_REPO_BRANCH}" ]]; then
     CROWSNEST_CAMERA_STREAMER_REPO_BRANCH="master"

--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -28,7 +28,7 @@ CN_CONFIG_ENVPATH="${CN_CONFIG_ROOTPATH}/systemd"
 CN_MOONRAKER_CONFIG_PATH="${CN_CONFIG_CONFIGPATH}/moonraker.conf"
 CN_USTREAMER_REPO="https://github.com/pikvm/ustreamer.git"
 CN_USTREAMER_BRANCH="master"
-CN_CAMERA_STREAMER_REPO="https://github.com/ayufan-research/camera-streamer.git"
+CN_CAMERA_STREAMER_REPO="https://github.com/ayufan/camera-streamer.git"
 CN_CAMERA_STREAMER_BRANCH="master"
 
 ### Messages

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -128,6 +128,12 @@ main() {
 
     add_group_video
 
+    if [[ "$(is_bookworm)" = "1" ]]; then
+        msg "Bookworm detected!"
+        msg "Using main branch of camera-streamer for Bookworm..."
+        CROWSNEST_CAMERA_STREAMER_REPO_BRANCH="main"
+    fi
+
     build_apps
 
     if [[ "${CROWSNEST_UNATTENDED}" = "0" ]]; then

--- a/tools/libs/core.sh
+++ b/tools/libs/core.sh
@@ -34,6 +34,12 @@ is_buster() {
     fi
 }
 
+is_bookworm() {
+    if [[ -f /etc/os-release ]]; then
+        grep -cq "bookworm" /etc/os-release &> /dev/null && echo "1" || echo "0"
+    fi
+}
+
 is_raspbian() {
     if [[ -f /boot/config.txt ]] && [[ -f /etc/rpi-issue ]]; then
         echo "1"


### PR DESCRIPTION
Fixes #188 
This will force the main branch of camera-streamer on Bookworm installations.
Therefore it will ignore the branch specified inside `tools/.config` on Bookworm installations.