### PR TITLE
Update moonraker_update.txt to replace missing pkglist.sh

### DIFF
--- a/resources/moonraker_update.txt
+++ b/resources/moonraker_update.txt
@@ -5,4 +5,4 @@ type: git_repo
 path: ~/crowsnest
 origin: https://github.com/mainsail-crew/crowsnest.git
 managed_services: crowsnest
-install_script: tools/pkglist.sh
+system_dependencies: tools/install.sh


### PR DESCRIPTION
pkglist.sh does not exist, guessing install.sh is its replacement

and 
```
install_script:
#  *** DEPRICATED FOR NEW CONFIGURATIONS - USE the 'system_dependencies' OPTION
```
 from [https://moonraker.readthedocs.io/en/latest/configuration/](https://moonraker.readthedocs.io/en/latest/configuration/)