### PR TITLE
fix: fixes error in detect_legacy

### DIFF
--- a/libs/hwhandler.sh
+++ b/libs/hwhandler.sh
@@ -86,8 +86,7 @@ get_libcamera_path() {
 # Determine connected "legacy" device
 function detect_legacy {
     local avail
-    if [[ -f /proc/device-tree/model ]] &&
-    grep -q "Raspberry" /proc/device-tree/model &&
+    if [[ "$(is_raspberry_pi)" = "1" ]] &&
     command -v vcgencmd &> /dev/null; then
         if vcgencmd get_camera &> /dev/null ; then
             avail="$(vcgencmd get_camera \

--- a/libs/hwhandler.sh
+++ b/libs/hwhandler.sh
@@ -87,12 +87,16 @@ get_libcamera_path() {
 function detect_legacy {
     local avail
     if [[ -f /proc/device-tree/model ]] &&
-    grep -q "Raspberry" /proc/device-tree/model; then
-        avail="$(vcgencmd get_camera | awk -F '=' '{ print $3 }' | cut -d',' -f1)"
-    else
-        avail="0"
+    grep -q "Raspberry" /proc/device-tree/model &&
+    command -v vcgencmd &> /dev/null; then
+        if vcgencmd get_camera &> /dev/null ; then
+            avail="$(vcgencmd get_camera \
+                    | awk -F '=' '{ print $3 }' \
+                    | cut -d',' -f1 \
+                    )"
+        fi
     fi
-    echo "${avail}"
+    echo "${avail:-0}"
 }
 
 function dev_is_legacy {


### PR DESCRIPTION
This will fix issue on Raspberry Pi5, which doesnt generate cam list,
because 'vcgencmd get_camera' exits with an error.
    
If all conditions fail it will always return '0'
    
Signed-off-by: Stephan Wendel <me@stephanwe.de>