### PR TITLE
fix: fix crash with brokenfocus and camera-streamer

### DIFF
--- a/libs/ustreamer.sh
+++ b/libs/ustreamer.sh
@@ -24,7 +24,7 @@ run_mjpg() {
         run_ustreamer "${instance}" &
     done
     blockyfix
-    brokenfocus
+    brokenfocus "${cams}"
     return
 }
 

--- a/libs/v4l2_control.sh
+++ b/libs/v4l2_control.sh
@@ -116,7 +116,7 @@ function brokenfocus {
 
     function main {
         local cur_val conf_val device
-        for cam in $(configured_cams); do
+        for cam in ${1}; do
             device="$(get_param "cam ${cam}" device)"
             cur_val="$(get_current_value "${device}")"
             conf_val="$(get_conf_value "${cam}")"
@@ -133,7 +133,7 @@ function brokenfocus {
     }
 
 ### MAIN
-main
+main "${1}"
 
 }
 


### PR DESCRIPTION
If one cam with `ustreamer` is defined it will run `brokenfocus` for every cam defined. This will lead to a crash with `brokenfocus` devices with mode `camera-streamer`.
This PR fixes this issue and will only run `brokenfocus` for devices with mode `ustreamer`