### PR TITLE
chore: shallow clone camera-streamer submodules

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -130,7 +130,7 @@ clone_cstreamer() {
     git clone "${CROWSNEST_CAMERA_STREAMER_REPO_SHIP}" \
         -b "${CROWSNEST_CAMERA_STREAMER_REPO_BRANCH}" \
         "${BASE_CN_BIN_PATH}"/"${CSTREAMER_PATH}" \
-        "${CLONE_FLAGS[@]}" --recursive
+        "${CLONE_FLAGS[@]}" --recurse-submodules --shallow-submodules
 }
 
 ### Clone Apps

--- a/tools/libs/build_apps.sh
+++ b/tools/libs/build_apps.sh
@@ -36,7 +36,8 @@ clone_cstreamer() {
         rm -rf bin/camera-streamer
     fi
     sudo -u "${BASE_USER}" \
-    git clone "${CROWSNEST_CAMERA_STREAMER_REPO_SHIP}" --recursive \
+    git clone "${CROWSNEST_CAMERA_STREAMER_REPO_SHIP}" \
+    --recurse-submodules --shallow-submodules \
     -b "${CROWSNEST_CAMERA_STREAMER_REPO_BRANCH}" \
     --depth=1 --single-branch bin/camera-streamer
 }


### PR DESCRIPTION
This reduces the download size and disk usage for `camera-streamer`.