### PR TITLE
chore: remove `buildclean` from `make update`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ help: ## Shows this help
 update: ## Update crowsnest (fetches and pulls repository changes)
 	@git fetch && git pull
 	@bash -c 'bin/build.sh --reclone'
-	${MAKE} buildclean
 	${MAKE} build
 
 report: ## Generate report.txt


### PR DESCRIPTION
`make update` reclones the repositories, so we don't need to clean them before building.