### PR TITLE
chore: add warning for libcamera on pi5

### DIFF
--- a/libs/logging.sh
+++ b/libs/logging.sh
@@ -100,6 +100,11 @@ function print_cams {
         log_msg "INFO: Found ${total} total available Device(s)"
     fi
     if [[ "${libcamera}" -ne 0 ]]; then
+        if [[ "$(is_pi5)" = "1" ]]; then
+            log_msg "================================================================"
+            log_msg " WARN: 'libcamera' devices are currently not supported on Pi 5! "
+            log_msg "================================================================"
+        fi
         for device in $(get_libcamera_path); do
             log_msg "Detected 'libcamera' device -> ${device}"
         done


### PR DESCRIPTION
We currently don't support libcamera devices on the Raspberry Pi 5.
This will add a warning before the libcamera device logging.