### PR TITLE
fix: fix ustreamer binary path for v5.52 changes

### DIFF
--- a/libs/core.sh
+++ b/libs/core.sh
@@ -82,11 +82,15 @@ function check_dep {
 
 function check_apps {
     local cstreamer ustreamer
-    ustreamer="bin/ustreamer/ustreamer"
+    ustreamer_base="bin/ustreamer"
+    ustreamer="$(find ${BASE_CN_PATH}/${ustreamer_base} \
+                -iname 'ustreamer.bin' 2> /dev/null | sed '1q')"
     cstreamer="bin/camera-streamer/camera-streamer"
 
-    if [[ -x "${BASE_CN_PATH}/${ustreamer}" ]]; then
-        log_msg "Dependency: '${ustreamer##*/}' found in ${ustreamer}."
+    if [[ -x "${ustreamer}" ]]; then
+        log_msg "Dependency: '${ustreamer##*/}' found in ${ustreamer_base}/${ustreamer##*/}."
+        UST_BIN="${ustreamer}"
+        declare -r UST_BIN
     else
         log_msg "Dependency: '${ustreamer##*/}' not found. Exiting!"
         exit 1

--- a/libs/ustreamer.sh
+++ b/libs/ustreamer.sh
@@ -31,7 +31,7 @@ run_mjpg() {
 run_ustreamer() {
     local cam_sec ust_bin dev pt res fps cstm start_param
     cam_sec="${1}"
-    ust_bin="${BASE_CN_PATH}/bin/ustreamer/ustreamer"
+    ust_bin="${UST_BIN}"
     dev="$(get_param "cam ${cam_sec}" device)"
     pt="$(get_param "cam ${cam_sec}" port)"
     res="$(get_param "cam ${cam_sec}" resolution)"

--- a/libs/versioncontrol.sh
+++ b/libs/versioncontrol.sh
@@ -28,7 +28,7 @@ versioncontrol() {
         local cur_ver avail_ver
         pushd "${BASE_CN_PATH}"/bin/ustreamer &> /dev/null || exit 1
             avail_ver="$(git describe --tags --always)"
-            cur_ver="v$("${PWD}"/ustreamer -v)"
+            cur_ver="v$("${UST_BIN}" -v)"
             if [[ "${cur_ver}" == "${avail_ver}" ]]; then
                 vc_log_msg "ustreamer is up to date. (${cur_ver})"
             fi


### PR DESCRIPTION
ustreamer changed the way the symlink to the binary is created https://github.com/pikvm/ustreamer/commit/3715c89ec8a5465d88ee672be28ad65c59c4599d
This PR searches for a `ustreamer.bin` inside the `bin/ustreamer` folder and declares a global variable for internal use.