### PR TITLE
fix: fix empty string if ustreamer not found

### DIFF
--- a/libs/core.sh
+++ b/libs/core.sh
@@ -82,18 +82,15 @@ function check_dep {
 
 function check_apps {
     local cstreamer ustreamer
-    ustreamer_base="bin/ustreamer"
-    ustreamer="$(find "${BASE_CN_PATH}"/"${ustreamer_base}" \
-                -iname 'ustreamer.bin' 2> /dev/null | sed '1q')"
+    ustreamer="bin/ustreamer/src/ustreamer.bin"
     cstreamer="bin/camera-streamer/camera-streamer"
-
-    if [[ -x "${ustreamer}" ]]; then
-        log_msg "Dependency: '${ustreamer##*/}' found in ${ustreamer_base}/${ustreamer##*/}."
-        UST_BIN="${ustreamer}"
+    if [[ -x "${BASE_CN_PATH}/${ustreamer}" ]]; then
+        log_msg "Dependency: 'ustreamer' found in ${ustreamer}."
+        UST_BIN="${BASE_CN_PATH}/${ustreamer}"
         # shellcheck disable=SC2034
         declare -r UST_BIN
     else
-        log_msg "Dependency: '$(dirname ustreamer_base)' not found. Exiting!"
+        log_msg "Dependency: 'ustreamer' not found. Exiting!"
         exit 1
     fi
 

--- a/libs/core.sh
+++ b/libs/core.sh
@@ -93,7 +93,7 @@ function check_apps {
         # shellcheck disable=SC2034
         declare -r UST_BIN
     else
-        log_msg "Dependency: '${ustreamer##*/}' not found. Exiting!"
+        log_msg "Dependency: '${ustreamer_base##*/}' not found. Exiting!"
         exit 1
     fi
 

--- a/libs/core.sh
+++ b/libs/core.sh
@@ -93,7 +93,7 @@ function check_apps {
         # shellcheck disable=SC2034
         declare -r UST_BIN
     else
-        log_msg "Dependency: '${ustreamer_base##*/}' not found. Exiting!"
+        log_msg "Dependency: '$(dirname ustreamer_base)' not found. Exiting!"
         exit 1
     fi
 


### PR DESCRIPTION
If ustreamer is not installed, the dependency check will print an empty string because it is not found.