### PR TITLE
fix: fix libcamera resolution and controls logging

### DIFF
--- a/libs/hwhandler.sh
+++ b/libs/hwhandler.sh
@@ -114,7 +114,7 @@ list_picam_controls() {
     local prefix
     prefix="$(date +'[%D %T]') crowsnest:"
     log_msg "'libcamera' device controls :"
-    while read -r i; do
+    while IFS= read -r i; do
         if [[ ! "${i}" =~ "INFO" ]]; then
             printf "%s\t\t%s\n" "${prefix}" "${i}" >>"${CROWSNEST_LOG_PATH}"
         fi

--- a/libs/hwhandler.sh
+++ b/libs/hwhandler.sh
@@ -87,7 +87,7 @@ list_picam_resolution() {
     local prefix
     prefix="$(date +'[%D %T]') crowsnest:"
     log_msg "'libcamera' device(s) resolution(s) :"
-    while read -r i; do
+    while IFS= read -r i; do
         printf "%s\t\t%s\n" "${prefix}" "${i}" >> "${CROWSNEST_LOG_PATH}"
     done < <(libcamera-hello --list-cameras | sed '1,2d;s/Modes:/Colorspace:/')
 }

--- a/libs/hwhandler.sh
+++ b/libs/hwhandler.sh
@@ -101,8 +101,8 @@ get_libcamera_controls() {
         sed 's/device//g;/^SNAPSHOT/q' | sed '/^SNAPSHOT/d' | \
         sed '/^CAMERA/d;/- property/d' | sed '/camera-streamer Version:/d' | \
         sed 's/- available option: //g' | sed '/^$/d;' | \
-        sed 's/([0-9]*[a-z,0-9]\,//g' | sed '/type=7/d;/type=4/d' | \
-        sed 's/type=1/ (bool/g;s/type=3/ (int/g;s/type=5/ (float/g' | \
+        sed 's/([0-9]*[a-z,0-9]\, /(/g' | sed '/type=7/d;/type=4/d;/type=Rectangle/d' | \
+        sed 's/type=1/bool/g;s/type=3/int/g;s/type=5/float/g' | sed 's/type=//g;' | \
         sed 's/\[/min=/g;s/\.\./ max=/g;s/\]$//g'
     else
         log_msg "WARN: 'libcamera' device option can not be displayed, because"


### PR DESCRIPTION
Fixes small style errors for picam logging:
- Added indentation of camera resolution
- Added indentation for camera controls modes
- Fixed type parsing for camera controls on Bookworm