### PR TITLE
docs: improve grammar and style, including capitalization and phrasing

### DIFF
--- a/resources/crowsnest.conf
+++ b/resources/crowsnest.conf
@@ -1,9 +1,8 @@
 #### crowsnest.conf
-#### This is a typical default config.
-#### Also used as default in mainsail / MainsailOS
-#### See:
+#### This is the default config after installation.
+#### It is also used as the default config in MainsailOS.
+#### For details on how to configure this to your needs, see:
 #### https://github.com/mainsail-crew/crowsnest/blob/master/README.md
-#### for details to configure to your needs.
 
 
 #####################################################################
@@ -18,8 +17,8 @@
 ####    Port 8083 equals /webcam4/?action=[stream/snapshot]     #####
 ####                                                            #####
 ####    Note: These ports are default for most Mainsail         #####
-####    installations. To use any other port would involve      #####
-####    changing the proxy configuration or using directly      #####
+####    installations. Using any other port would involve       #####
+####    changing the proxy configuration or directly using      #####
 ####    http://<ip>:<port>/?action=[stream/snapshot]            #####
 ####                                                            #####
 #####################################################################
@@ -32,16 +31,16 @@
 log_path: %LOGPATH%
 log_level: verbose                      # Valid Options are quiet/verbose/debug
 delete_log: false                       # Deletes log on every restart, if set to true
-no_proxy: false                         # If true the server listen on all interfaces, not just localhost
+no_proxy: false                         # Listen on all interfaces, not just localhost, if set to true
 
 [cam 1]
-mode: ustreamer                         # ustreamer - Provides mjpg and snapshots. (All devices)
-                                        # camera-streamer - Provides webrtc, mjpg and snapshots. (rpi + Raspi OS based only)
-enable_rtsp: false                      # If camera-streamer is used, this enables also usage of an rtsp server
+mode: ustreamer                         # ustreamer - Provides MJPG and snapshots. (All devices)
+                                        # camera-streamer - Provides WebRTC, MJPG and snapshots. (Raspi OS based only)
+enable_rtsp: false                      # If camera-streamer is used, this also enables usage of an RTSP server
 rtsp_port: 8554                         # Set different ports for each device!
-port: 8080                              # HTTP/MJPG Stream/Snapshot Port
-device: /dev/video0                     # See Log for available ...
-resolution: 640x480                     # widthxheight format
-max_fps: 15                             # If Hardware Supports this it will be forced, otherwise ignored/coerced.
-#custom_flags:                          # You can run the Stream Services with custom flags.
-#v4l2ctl:                               # Add v4l2-ctl parameters to setup your camera, see Log what your cam is capable of.
+port: 8080                              # HTTP/MJPG stream/snapshot port
+device: /dev/video0                     # See log for available devices
+resolution: 640x480                     # <width>x<height> format
+max_fps: 15                             # If hardware supports it, it will be forced, otherwise ignored/coerced.
+#custom_flags:                          # You can run the stream services with custom flags.
+#v4l2ctl:                               # Add v4l2-ctl parameters to setup your camera, see log for your camera capabilities.

--- a/resources/crowsnest.conf
+++ b/resources/crowsnest.conf
@@ -36,7 +36,7 @@ no_proxy: false                         # If set to true, no reverse proxy is re
 
 [cam 1]
 mode: ustreamer                         # ustreamer - Provides MJPG and snapshots. (All devices)
-                                        # camera-streamer - Provides WebRTC, MJPG and snapshots. (only RPiOS based + RPi 0/1/2/3/4)
+                                        # camera-streamer - Provides WebRTC, MJPG and snapshots. (only RPiOS + RPi 0/1/2/3/4)
 enable_rtsp: false                      # If camera-streamer is used, this also enables usage of an RTSP server
 rtsp_port: 8554                         # Set different ports for each device!
 port: 8080                              # HTTP/MJPG stream/snapshot port

--- a/resources/crowsnest.conf
+++ b/resources/crowsnest.conf
@@ -31,7 +31,7 @@
 log_path: %LOGPATH%
 log_level: verbose                      # Valid Options are quiet/verbose/debug
 delete_log: false                       # Deletes log on every restart, if set to true
-no_proxy: false                         # Listen on all interfaces, not just localhost, if set to true
+no_proxy: false                         # If set to true, no reverse proxy is required. Only change this, if you know what you are doing.
 
 [cam 1]
 mode: ustreamer                         # ustreamer - Provides MJPG and snapshots. (All devices)

--- a/resources/crowsnest.conf
+++ b/resources/crowsnest.conf
@@ -32,7 +32,7 @@
 log_path: %LOGPATH%
 log_level: verbose                      # Valid Options are quiet/verbose/debug
 delete_log: false                       # Deletes log on every restart, if set to true
-no_proxy: false
+no_proxy: false                         # If true the server listen on all interfaces, not just localhost
 
 [cam 1]
 mode: ustreamer                         # ustreamer - Provides mjpg and snapshots. (All devices)

--- a/resources/crowsnest.conf
+++ b/resources/crowsnest.conf
@@ -18,7 +18,8 @@
 ####                                                            #####
 ####    Note: These ports are default for most Mainsail         #####
 ####    installations. Using any other port would involve       #####
-####    changing the proxy configuration or directly using      #####
+####    changing the proxy configuration or using URLs          #####
+####    with the specific port like                             #####
 ####    http://<ip>:<port>/?action=[stream/snapshot]            #####
 ####                                                            #####
 #####################################################################
@@ -35,7 +36,7 @@ no_proxy: false                         # If set to true, no reverse proxy is re
 
 [cam 1]
 mode: ustreamer                         # ustreamer - Provides MJPG and snapshots. (All devices)
-                                        # camera-streamer - Provides WebRTC, MJPG and snapshots. (Raspi OS based only)
+                                        # camera-streamer - Provides WebRTC, MJPG and snapshots. (only RPiOS based + RPi 0/1/2/3/4)
 enable_rtsp: false                      # If camera-streamer is used, this also enables usage of an RTSP server
 rtsp_port: 8554                         # Set different ports for each device!
 port: 8080                              # HTTP/MJPG stream/snapshot port


### PR DESCRIPTION
The example crowsnet.conf does not specify what use_proxy is for and it is not immediately obvious. 

The issue is discussed in #34 