### PR TITLE
fix: fix ustreamer dependencies

### DIFF
--- a/tools/libs/pkglist-generic.sh
+++ b/tools/libs/pkglist-generic.sh
@@ -20,4 +20,4 @@ set -Ee
 ### Crowsnest Dependencies
 PKGLIST="git crudini bsdutils findutils v4l-utils curl"
 ### Ustreamer Dependencies
-PKGLIST="${PKGLIST} build-essential libevent-dev libjpeg-dev libbsd-dev"
+PKGLIST="${PKGLIST} build-essential libevent-dev libjpeg-dev libbsd-dev pkg-config"

--- a/tools/libs/pkglist-rpi.sh
+++ b/tools/libs/pkglist-rpi.sh
@@ -22,7 +22,7 @@ set -Ee
 ### Crowsnest Dependencies
 PKGLIST="git crudini bsdutils findutils v4l-utils curl"
 ### Ustreamer Dependencies
-PKGLIST="${PKGLIST} build-essential libevent-dev libjpeg-dev libbsd-dev"
+PKGLIST="${PKGLIST} build-essential libevent-dev libjpeg-dev libbsd-dev pkg-config"
 ### Camera-Streamer Dependencies
 ### If you change something below, also have a look at tools/libs/core.sh->shallow_cs_dependencies_check
 PKGLIST="${PKGLIST} cmake libavformat-dev libavutil-dev libavcodec-dev libcamera-dev libcamera-apps-lite"


### PR DESCRIPTION
Ustreamer added pkg-config in v6.13 as dependency. This might not be required to build but is checked in the Makefile.