### PR TITLE
chore: remove rtsp options from crowsnest.conf example

### DIFF
--- a/resources/crowsnest.conf
+++ b/resources/crowsnest.conf
@@ -37,8 +37,6 @@ no_proxy: false                         # If set to true, no reverse proxy is re
 [cam 1]
 mode: ustreamer                         # ustreamer - Provides MJPG and snapshots. (All devices)
                                         # camera-streamer - Provides WebRTC, MJPG and snapshots. (only RPiOS + RPi 0/1/2/3/4)
-enable_rtsp: false                      # If camera-streamer is used, this also enables usage of an RTSP server
-rtsp_port: 8554                         # Set different ports for each device!
 port: 8080                              # HTTP/MJPG stream/snapshot port
 device: /dev/video0                     # See log for available devices
 resolution: 640x480                     # <width>x<height> format


### PR DESCRIPTION
As described in https://github.com/mainsail-crew/crowsnest/issues/303 we remove `enable_rtsp` and `rtsp_port` as RTSP is currently not working anymore on latest Bookworm system packages.

Furthermore people are just mindlessly enabling it without even knowing what it does. Therefore we remove the option from the example config. The option is still available to use and can be found in our [docs](https://crowsnest.mainsail.xyz/configuration/cam-section#enable_rtsp).