### PR TITLE
fix: fix libcamera device detection on bookworm

### DIFF
--- a/libs/hwhandler.sh
+++ b/libs/hwhandler.sh
@@ -72,7 +72,7 @@ list_libcameras() {
     if [[ -x "$(command -v libcamera-hello)" ]]; then
         libcamera-hello --list-cameras
     else
-        rpicam-hello --list-camera
+        rpicam-hello --list-cameras
     fi
 }
 

--- a/libs/hwhandler.sh
+++ b/libs/hwhandler.sh
@@ -57,12 +57,31 @@ list_cam_v4l2ctrls() {
     done < <(v4l2-ctl -d "${device}" --list-ctrls-menus)
 }
 
+## Detect libcamera package
+libcamera_installed() {
+    if [[ -x "$(command -v libcamera-hello)" ]] ||
+    [[ -x "$(command -v rpicam-hello)" ]]; then
+        echo "1"
+    else
+        echo "0"
+    fi
+}
+
+## List libcamera (CSI) device
+list_libcameras() {
+    if [[ -x "$(command -v libcamera-hello)" ]]; then
+        libcamera-hello --list-cameras
+    else
+        rpicam-hello --list-camera
+    fi
+}
+
 ## Determine connected libcamera (CSI) device
 detect_libcamera() {
     local avail
     if [[ "$(is_raspberry_pi)" = "1" ]] &&
-    [[ -x "$(command -v libcamera-hello)" ]]; then
-        avail="$(libcamera-hello --list-cameras | grep -c "Available" || echo "0")"
+    [[ "$(libcamera_installed)" = "1" ]]; then
+        avail="$(list_libcameras | grep -c "Available" || echo "0")"
         if [[ "${avail}" = "1" ]]; then
             get_libcamera_path | wc -l
         else
@@ -73,13 +92,10 @@ detect_libcamera() {
     fi
 }
 
-## Spit /base/soc path for libcamera device
+## Split /base/soc path for libcamera device
 get_libcamera_path() {
-    if [[ "$(is_raspberry_pi)" = "1" ]] &&
-    [[ -x "$(command -v libcamera-hello)" ]]; then
-        libcamera-hello --list-cameras | sed '1,2d' \
-        | grep "\(/base/*\)" | cut -d"(" -f2 | tr -d '$)'
-    fi
+    list_libcameras | sed '1,2d' \
+    | grep "\(/base/*\)" | cut -d"(" -f2 | tr -d '$)'
 }
 
 # print libcamera resolutions


### PR DESCRIPTION
The Raspberry Pi Foundation removed the symlinks to the libcamera-apps on Bookworm resulting in a broken libcamera device detection. This commit fixes this by looking for rpicam-apps (the newer package) and for libcamera-apps (the old package) to achieve backwards compatibility with Bullseye.
https://github.com/raspberrypi/rpicam-apps/commit/057add601fe3bdcaaf2ab41df4f5fa646e4681b3