### PR TITLE
chore: update git actions in release.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,14 +37,14 @@ jobs:
         run: |
           echo "TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v2
+        uses: orhun/git-cliff-action@v4
         id: generate-changelog
         with:
           config: ./cliff-release.toml
           args: ${{ steps.latest_tag.outputs.TAG_NAME }}..HEAD
 
       - name: Create release and upload build
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         id: create-release
         with:
           name: v${{ github.event.inputs.version }}
@@ -70,7 +70,7 @@ jobs:
         run: |
           echo "TAG_NAME=$(git describe --tags $(git rev-list --tags --max-count=1))" >> $GITHUB_OUTPUT
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v2
+        uses: orhun/git-cliff-action@v4
         id: git-cliff
         with:
           config: cliff.toml


### PR DESCRIPTION
Update git-cliff-action from v2 to v4 and action-gh-release from v1 to v2 in the release action.
This fixes the release action, as git-cliff-action v2 was using a a Buster Docker image.