### PR TITLE
ci: fix shellcheck failing

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -14,7 +14,7 @@
 # shellcheck enable=require-variable-braces
 
 ### Disable SC2317 due Trap usage
-# shellcheck disable=SC2317
+# shellcheck disable=SC2317,SC2329
 
 # Exit on errors
 set -Ee

--- a/tools/dev-helper.sh
+++ b/tools/dev-helper.sh
@@ -11,8 +11,8 @@
 
 # shellcheck enable=require-variable-braces
 
-### Disable SC2317
-# shellcheck disable=SC2317
+### Disable SC2317 and SC2329
+# shellcheck disable=SC2317,SC2329
 
 # Exit on errors
 set -Ee


### PR DESCRIPTION
The failing functions are used but on different file paths, therefore shellcheck breaks.

We don't know why it suddenly fails. Ignoring it seems like the easiest fix for now.