### PR TITLE
fix: fix apt failed message redirecting to Discord

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -63,7 +63,7 @@ main() {
     if run_apt_update; then
         status_msg "Running apt-get update first ..." "0"
     else
-        status_msg "Running apt-get update first ..." "1"
+        status_msg "Running apt-get update first ..." "4"
     fi
 
     if [[ "${CROWSNEST_UNATTENDED}" != "1" ]]; then

--- a/tools/libs/messages.sh
+++ b/tools/libs/messages.sh
@@ -49,6 +49,11 @@ status_msg() {
     if [[ "${status}" == "3" ]]; then
         echo -e "${msg} [\e[33mFAILED\e[0m]"
     fi
+    if [[ "${status}" == "4" ]]; then
+        echo -e "${msg} [\e[33mFAILED\e[0m]"
+        apt_failed_msg
+        exit 1
+    fi
 }
 
 not_as_root_msg() {
@@ -95,4 +100,9 @@ error_msg() {
     msg "Something went wrong!\nPlease copy the latest output, head over to\n"
     msg "\thttps://discord.gg/mainsail\n"
     msg "and open a ticket in #supportforum..."
+}
+
+apt_failed_msg() {
+    msg "There is a problem with your apt sources.\n"
+    msg "Please fix your sytem first and then try again."
 }


### PR DESCRIPTION
If apt update fails, the installer redirects to our Discord. As this is not a problem with our installer or a problem we can influence, and often a matter of just a quick google search, we decided to remove the redirect to our Discord.
This should incentivise the user to learn more about such problems and the reason why it appears.
We will ofc still help with any problems people may have on our Discord or in our GitHub Discussions.