### PR TITLE
fix(spyglass): add warning about crash with resolution above 1080p

### DIFF
--- a/crowsnest/components/streamer/spyglass.py
+++ b/crowsnest/components/streamer/spyglass.py
@@ -84,6 +84,18 @@ class Spyglass(Streamer):
 
         return process
 
+    def check_config_section(self, config_section: SectionProxy) -> bool:
+        height, width = self.parameters["resolution"]
+        custom_flags = self.parameters["custom_flags"].split()
+        sw_encoding = "-sw" in custom_flags or "--use-sw-encoding" in custom_flags
+        check_res = not utils.is_pi5() and not sw_encoding
+        if check_res and int(height) > 1920 and int(width) > 1080:
+            self.log_warn(
+                "Potential crash detected. Please reduce resolution to 1920x1080 or "
+                "lower to stay within hardware constraints."
+            )
+        super().check_config_section(config_section)
+
 
 def load_streamer() -> tuple[list[str], list[str]]:
     return Spyglass.binary_names, Spyglass.binary_paths

--- a/crowsnest/components/streamer/spyglass.py
+++ b/crowsnest/components/streamer/spyglass.py
@@ -85,16 +85,16 @@ class Spyglass(Streamer):
         return process
 
     def check_config_section(self, config_section: SectionProxy) -> bool:
-        height, width = self.parameters["resolution"]
+        width, height = self.parameters["resolution"]
         custom_flags = self.parameters["custom_flags"].split()
         sw_encoding = "-sw" in custom_flags or "--use-sw-encoding" in custom_flags
         check_res = not utils.is_pi5() and not sw_encoding
-        if check_res and int(height) > 1920 and int(width) > 1080:
-            self.log_warn(
+        if check_res and int(width) > 1920 and int(height) > 1080:
+            self.log_warning(
                 "Potential crash detected. Please reduce resolution to 1920x1080 or "
                 "lower to stay within hardware constraints."
             )
-        super().check_config_section(config_section)
+        return super().check_config_section(config_section)
 
 
 def load_streamer() -> tuple[list[str], list[str]]:


### PR DESCRIPTION
Due to hardware limitations of the HW encoder of the Pi resolutions above 1920x1080 can crash spyglass.
This is not the exact limit and the user could push it a little bit higher but this is the last sane resolution that should be chosen. This limit is not intact for Pi5 or when setting the SW encoder flag.