### PR TITLE
fix: fix early exiting sections not logging anything

### DIFF
--- a/crowsnest/components/cam.py
+++ b/crowsnest/components/cam.py
@@ -42,7 +42,9 @@ class Cam(Section):
             return False
         return self.streamer.initialized
 
-    async def execute(self, lock: asyncio.Lock) -> Optional[asyncio.subprocess.Process]:
+    async def execute(
+        self, lock: asyncio.Lock
+    ) -> Optional[asyncio.subprocess.Process | int]:
         if self.streamer is None:
             self.log_error("No streamer loaded!")
             return
@@ -54,20 +56,19 @@ class Cam(Section):
             )
             watchdog.configured_devices.append(self.streamer.parameters["device"])
             process = await self.streamer.execute(lock)
-            if process:
+            if process is not None:
                 await process.wait()
-            else:
-                self.log_error(f"Start of {self.parameters['mode']} failed!")
-            return process.returncode
+                return process.returncode
         except Exception:
             self.log_multiline(traceback.format_exc().strip(), logger.log_error)
-            self.log_error(f"Start of {self.parameters['mode']} failed!")
-            return None
         finally:
             if self.streamer.parameters["device"] in watchdog.configured_devices:
                 watchdog.configured_devices.remove(self.streamer.parameters["device"])
             if lock.locked():
                 lock.release()
+
+        self.log_error(f"Start of {self.parameters['mode']} failed!")
+        return None
 
 
 def load_component(name: str, config_section: SectionProxy) -> Cam:

--- a/crowsnest/components/cam.py
+++ b/crowsnest/components/cam.py
@@ -58,9 +58,11 @@ class Cam(Section):
                 await process.wait()
             else:
                 self.log_error(f"Start of {self.parameters['mode']} failed!")
+            return process.returncode
         except Exception:
             self.log_multiline(traceback.format_exc().strip(), logger.log_error)
             self.log_error(f"Start of {self.parameters['mode']} failed!")
+            return None
         finally:
             if self.streamer.parameters["device"] in watchdog.configured_devices:
                 watchdog.configured_devices.remove(self.streamer.parameters["device"])

--- a/crowsnest/components/section.py
+++ b/crowsnest/components/section.py
@@ -55,7 +55,9 @@ class Section(ABC):
         self.parameters: dict[str, Any] = {}
 
     @abstractmethod
-    async def execute(self, lock: asyncio.Lock) -> Optional[asyncio.subprocess.Process]:
+    async def execute(
+        self, lock: asyncio.Lock
+    ) -> Optional[asyncio.subprocess.Process | int]:
         raise NotImplementedError("If you see this, something went wrong!!!")
 
     def __getattr__(self, name):

--- a/crowsnest/crowsnest.py
+++ b/crowsnest/crowsnest.py
@@ -42,6 +42,17 @@ def initial_parse_config(config_path, config):
     return crowsnest
 
 
+async def task_watchdog(pending):
+    while pending:
+        done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+
+        for task in done:
+            name = task.get_name()
+            exit_code = task.result()
+
+            logger.log_info(f"{name} exited with code {exit_code}")
+
+
 async def start_sections(config):
     sect_objs = []
     sect_exec_tasks = set()
@@ -79,7 +90,10 @@ async def start_sections(config):
         if sect_objs:
             lock = asyncio.Lock()
             for section_object in sect_objs:
-                task = asyncio.create_task(section_object.execute(lock))
+                task = asyncio.create_task(
+                    section_object.execute(lock),
+                    name=f"[{section_object.section_name} {section_object.name}]",
+                )
                 sect_exec_tasks.add(task)
 
             # Lets sect_exec_tasks finish first
@@ -89,9 +103,7 @@ async def start_sections(config):
         else:
             logger.log_quiet("No Service started! Exiting ...")
 
-        for task in sect_exec_tasks:
-            if task is not None:
-                await task
+        await task_watchdog(sect_exec_tasks)
     except Exception as e:
         logger.log_multiline(traceback.format_exc().strip(), logger.log_error)
     finally:

--- a/crowsnest/crowsnest.py
+++ b/crowsnest/crowsnest.py
@@ -48,8 +48,12 @@ async def task_watchdog(pending):
         for task in done:
             name = task.get_name()
             exit_code = task.result()
-            if exit_code is not None:
-                logger.log_info(f"{name} exited with code {exit_code}")
+            if exit_code is None:
+                continue
+            log_fn = logger.log_info
+            if exit_code > 0:
+                log_fn = logger.log_error
+            log_fn(f"{name} exited with code {exit_code}")
 
 
 async def start_sections(config):

--- a/crowsnest/crowsnest.py
+++ b/crowsnest/crowsnest.py
@@ -45,12 +45,11 @@ def initial_parse_config(config_path, config):
 async def task_watchdog(pending):
     while pending:
         done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
-
         for task in done:
             name = task.get_name()
             exit_code = task.result()
-
-            logger.log_info(f"{name} exited with code {exit_code}")
+            if exit_code is not None:
+                logger.log_info(f"{name} exited with code {exit_code}")
 
 
 async def start_sections(config):


### PR DESCRIPTION
If a section, like a cam, exits early because of an error it did not log anything. Now it will log the exit code of that section.