### PR TITLE
fix: fix multi-instance installations

### DIFF
--- a/tools/configure.sh
+++ b/tools/configure.sh
@@ -41,7 +41,7 @@ welcome_msg() {
     echo -e "This will guide you through install configuration"
     echo -e "After successful configuration use\n"
     echo -e "\t\e[32msudo make install\e[0m\n"
-    echo -e "to install crowsnest ..."
+    echo -e "to install crowsnest if not done already ..."
 }
 
 abort_msg() {

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -34,6 +34,7 @@ PKGLIST_PI=("python3-libcamera")
 
 main() {
     . "${SRC_DIR}/libs/helper_fn.sh"
+    . "${SRC_DIR}/libs/multi_instance.sh"
     . "${SRC_DIR}/libs/config.sh"
     . "${SRC_DIR}/libs/manage_apps.sh"
     . "${SRC_DIR}/libs/core.sh"

--- a/tools/libs/config.sh
+++ b/tools/libs/config.sh
@@ -3,7 +3,9 @@
 #### crowsnest - A webcam Service for multiple Cams and Stream Services.
 ####
 #### Written by Stephan Wendel aka KwadFan <me@stephanwe.de>
-#### Copyright 2021 - till today
+#### Copyright 2021 - 2026
+#### Co-authored by Patrick Gehrsitz aka mryel00 <mryel00.github@gmail.com>
+#### Copyright 2026 - till today
 #### https://github.com/mainsail-crew/crowsnest
 ####
 #### This File is distributed under GPLv3
@@ -20,8 +22,12 @@ set -Ee
 import_config() {
     msg "Reading configuration ..."
     ## Source config if present
+    if [[ ! -f "${SRC_DIR}/.config" ]]; then
+        check_multi_instance
+    fi
+
     if [[ -s "${SRC_DIR}/.config" ]]; then
-    msg "User configuration file found ..."
+        msg "User configuration file found ..."
         # shellcheck disable=SC1091
         if source "${SRC_DIR}/.config"; then
             status_msg "Import of user configuration ..." "0"

--- a/tools/libs/multi_instance.sh
+++ b/tools/libs/multi_instance.sh
@@ -26,7 +26,7 @@ check_multi_instance(){
     multi_instance_message "${instances[*]}"
     if [[ -d "/home/${BASE_USER}/crowsnest" ]]; then
       pushd "/home/${BASE_USER}/crowsnest" &> /dev/null || exit 1
-      if ! sudo -u ${BASE_USER} make config ;then
+      if ! sudo -u "${BASE_USER}" make config ;then
         msg "Something went wrong! Please try again..."
         if [[ -f "${SRC_DIR}/.config" ]]; then
           rm -f "${SRC_DIR}/.config"

--- a/tools/libs/multi_instance.sh
+++ b/tools/libs/multi_instance.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+#=======================================================================#
+# Copyright (C) 2020 - 2024 Dominik Willner <th33xitus@gmail.com>       #
+#                                                                       #
+# This file may be distributed under the terms of the GNU GPLv3 license #
+#=======================================================================#
+
+#=======================================================================#
+# Crowsnest Installer brought to you by KwadFan <me@stephanwe.de>       #
+# Copyright (C) 2022 KwadFan <me@stephanwe.de>                          #
+# https://github.com/KwadFan/crowsnest                                  #
+#=======================================================================#
+
+# This file is created from code snippets of https://github.com/dw-0/kiauh/tree/v5
+# and slightly adjusted to fit into Crowsnest
+
+# Exit on errors
+set -Ee
+
+check_multi_instance(){
+  local -a instances
+  readarray -t instances < <(find "/home/${BASE_USER}" -regex "/home/${BASE_USER}/[a-zA-Z0-9_]+_data/*" -printf "%P\n" 2> /dev/null | sort)
+  if [[ "${#instances[@]}" -gt 1 ]]; then
+    msg "Multi instance install detected ..."
+    multi_instance_message "${instances[*]}"
+    if [[ -d "/home/${BASE_USER}/crowsnest" ]]; then
+      pushd "/home/${BASE_USER}/crowsnest" &> /dev/null || exit 1
+      if ! sudo -u ${BASE_USER} make config ;then
+        msg "Something went wrong! Please try again..."
+        if [[ -f "${SRC_DIR}/.config" ]]; then
+          rm -f "${SRC_DIR}/.config"
+        fi
+        exit 1
+      fi
+      if [[ ! -f "${SRC_DIR}/.config" ]]; then
+        msg "failure while generating .config"
+        msg "Generating .config failed, installation aborted"
+        exit 1
+      fi
+      popd &> /dev/null || exit 1
+    fi
+  fi
+}
+
+multi_instance_message(){
+  echo -e "Crowsnest is NOT designed to support multi instances."
+  echo -e "A workaround for this is to choose the most used instance as a 'master'"
+  echo -e "Use this instance to set up your 'crowsnest.conf' and steering it's service.\n"
+  echo -e "Found the following instances:\n"
+  for i in ${1}; do
+    select_msg "${i}"
+  done
+  echo -e "\nLaunching crowsnest's configuration tool ..."
+  continue_config
+}
+
+select_msg() {
+  echo -e "   [➔] ${1}"
+}
+
+continue_config() {
+  local reply
+  while true; do
+    read -erp "###### Continue with configuration? (y/N): " reply
+    case "${reply}" in
+      Y|y|Yes|yes)
+        select_msg "Yes"
+        break;;
+      N|n|No|no|"")
+        select_msg "No"
+        msg "Installation aborted by user ... Exiting!"
+        exit 1;;
+      *)
+        msg "Invalid Input!\n";;
+    esac
+  done
+}


### PR DESCRIPTION
If you run `sudo make install` you can run into issues on a multi-instance installation. Installers like kiauh normall detect this and run `make config` beforehand, to mitigate the issues. The upgrade to v5 on the other hand, is a manual progress and will not account for this, unless there is already a `tools/.config` file laying around from previous installations.
Therefore this PR adds a multi-instance check and calls `make config` for you.