### PR TITLE
fix: fix typing error for Debian Bullseye

### DIFF
--- a/crowsnest/components/cam.py
+++ b/crowsnest/components/cam.py
@@ -10,7 +10,7 @@
 import asyncio
 import traceback
 from configparser import SectionProxy
-from typing import Optional
+from typing import Union
 
 from .. import logger, utils, watchdog
 from .section import Section
@@ -44,7 +44,7 @@ class Cam(Section):
 
     async def execute(
         self, lock: asyncio.Lock
-    ) -> Optional[asyncio.subprocess.Process | int]:
+    ) -> Union[asyncio.subprocess.Process, int, None]:
         if self.streamer is None:
             self.log_error("No streamer loaded!")
             return

--- a/crowsnest/components/section.py
+++ b/crowsnest/components/section.py
@@ -11,7 +11,7 @@ import asyncio
 import functools
 from abc import ABC, abstractmethod
 from configparser import SectionProxy
-from typing import Any, Optional
+from typing import Any, Union
 
 from .. import logger
 
@@ -57,7 +57,7 @@ class Section(ABC):
     @abstractmethod
     async def execute(
         self, lock: asyncio.Lock
-    ) -> Optional[asyncio.subprocess.Process | int]:
+    ) -> Union[asyncio.subprocess.Process, int, None]:
         raise NotImplementedError("If you see this, something went wrong!!!")
 
     def __getattr__(self, name):


### PR DESCRIPTION
`Optional[foo|bar]` was introduced with Python 3.10. Debian Bullseye is using Python 3.9. This seems to be the only problem preventing it from running on Python 3.9.