### PR TITLE
fix: fix execute_shell_command for rpicam edge case

### DIFF
--- a/crowsnest/camera/types/libcamera.py
+++ b/crowsnest/camera/types/libcamera.py
@@ -85,7 +85,7 @@ class Libcamera(camera.Camera):
         if not cmd:
             return []
         libcam_cmd = f"{cmd} --list-cameras"
-        libcam = utils.execute_shell_command(libcam_cmd, strip=False)
+        libcam = utils.execute_shell_command(libcam_cmd, strip=False, check=False)
         cams = [Libcamera(path) for path in re.findall(r"\((/base.*?)\)", libcam)]
         for cam in cams:
             cam.formats = cam._get_formats(libcam)

--- a/crowsnest/utils.py
+++ b/crowsnest/utils.py
@@ -83,13 +83,19 @@ async def execute_command(
     return process, stdout_task, stderr_task
 
 
-def execute_shell_command(command: str, strip: bool = True) -> str:
+def execute_shell_command(command: str, strip: bool = True, check: bool = True) -> str:
     try:
-        output = subprocess.check_output(shlex.split(command)).decode("utf-8")
+        output = subprocess.run(
+            shlex.split(command),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=check,
+        ).stdout
         if strip:
             output = output.strip()
         return output
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError:
         return ""
 
 


### PR DESCRIPTION
Sometimes the `rpicam-hello --list-cameras` can throw an error but will still print the cameras:
```sh
Available cameras
-----------------
0 : imx219 [3280x2464 10-bit RGGB] (/base/soc/i2c0mux/i2c@1/imx219@10)
    Modes: 'SRGGB10_CSI2P' : 640x480 [206.65 fps - (1000, 752)/1280x960
crop]
                             1640x1232 [41.85 fps - (0, 0)/3280x2464
crop]
                             1920x1080 [47.57 fps - (680, 692)/1920x1080
crop]
                             3280x2464 [21.19 fps - (0, 0)/3280x2464
crop]
           'SRGGB8' : 640x480 [206.65 fps - (1000, 752)/1280x960 crop]
                      1640x1232 [83.70 fps - (0, 0)/3280x2464 crop]
                      1920x1080 [47.57 fps - (680, 692)/1920x1080 crop]
                      3280x2464 [21.19 fps - (0, 0)/3280x2464 crop]

ERROR:  failed to generate capture configuration
```
This results in a non zero exit code and therefore `check_output` would result in a `CalledProcessError`.

This will fix the issue for this edge case but keeps the same behavior for other `execute_shell_command` calls.