### PR TITLE
fix(uvc): fix crash if class for camera controls is missing

### DIFF
--- a/crowsnest/camera/camera.py
+++ b/crowsnest/camera/camera.py
@@ -9,12 +9,13 @@
 
 import os
 from abc import ABC, abstractmethod
+from collections import defaultdict
 
 
 class Camera(ABC):
     def __init__(self, path: str, *args, **kwargs) -> None:
         self.path = path
-        self.control_values = {}
+        self.control_values = defaultdict(dict)
         self.formats = {}
 
     def path_equals(self, path: str) -> bool:

--- a/crowsnest/camera/types/uvc.py
+++ b/crowsnest/camera/types/uvc.py
@@ -33,7 +33,6 @@ class UVC(camera.Camera):
             parsed_qc = v4l2.ctl.parse_qc_of_path(self.path, qc)
             if not parsed_qc:
                 cur_sec = name
-                self.control_values[cur_sec] = {}
                 continue
             self.control_values[cur_sec][name] = parsed_qc
         self.formats = v4l2.ctl.get_formats(self.path)
@@ -55,7 +54,8 @@ class UVC(camera.Camera):
     def get_controls_string(self) -> str:
         message = ""
         for section, controls in self.control_values.items():
-            message += f"{section}:\n"
+            if section != "":
+                message += f"{section}:\n"
             for control, data in controls.items():
                 line = f"{control} ({data['type']})"
                 line += max(0, 35 - len(line)) * " " + ":"


### PR DESCRIPTION
The old code assumes that there will always be a leading class for camera controls returned by the camera, e.g. "User Controls" or "Camera Controls".
On older Linux kernel versions, e.g. 4.19, this doesn't seem to be the case leading to a crash.
This PR fixes this by using a `defaultdict` for the camera controls.