### PR TITLE
Workaround for cheap misreporting webcam

### DIFF
--- a/crowsnest/v4l2/ctl.py
+++ b/crowsnest/v4l2/ctl.py
@@ -41,7 +41,7 @@ def parse_qc(fd: int, qc: raw.v4l2_query_ext_ctrl) -> dict:
     if qc.type in (
         constants.V4L2_CTRL_TYPE_MENU,
         constants.V4L2_CTRL_TYPE_INTEGER_MENU,
-    ):
+    ) and qc.minimum > 0:
         controls["menu"] = {}
         for menu in utils.ioctl_iter(
             fd,


### PR DESCRIPTION
It looks like the camera advertises that it has a menu but then that component is just empty.

Adding this additional constraint fixed my webcam, but it's not obvious to the reader why this is the case.

The traceback I was chasing down is as follows:

    [06/05/26 23:54:35] INFO: Detect available Devices
    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "/home/klipper/crowsnest/crowsnest/__main__.py", line 8, in <module>
        asyncio.run(main())
      File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
        return runner.run(main)
               ^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
        return self._loop.run_until_complete(task)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
        return future.result()
               ^^^^^^^^^^^^^^^
      File "/home/klipper/crowsnest/crowsnest/crowsnest.py", line 195, in main
        logging_helper.log_cams()
      File "/home/klipper/crowsnest/crowsnest/logging_helper.py", line 114, in log_cams
        uvc = camera.camera_manager.init_camera_type(camera.UVC)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/klipper/crowsnest/crowsnest/camera/camera_manager.py", line 22, in init_camera_type
        cams = obj.init_camera_type()
               ^^^^^^^^^^^^^^^^^^^^^^
      File "/home/klipper/crowsnest/crowsnest/camera/types/uvc.py", line 108, in init_camera_type
        return [
               ^
      File "/home/klipper/crowsnest/crowsnest/camera/types/uvc.py", line 109, in <listcomp>
        UVC(dev_path, other=other_paths)
      File "/home/klipper/crowsnest/crowsnest/camera/types/uvc.py", line 33, in __init__
        parsed_qc = v4l2.ctl.parse_qc_of_path(self.path, qc)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/klipper/crowsnest/crowsnest/v4l2/ctl.py", line 69, in parse_qc_of_path
        controls = parse_qc(fd, qc)
                   ^^^^^^^^^^^^^^^^
      File "/home/klipper/crowsnest/crowsnest/v4l2/ctl.py", line 46, in parse_qc
        for menu in utils.ioctl_iter(
      File "/home/klipper/crowsnest/crowsnest/v4l2/utils.py", line 35, in ioctl_iter
        for i in range(start, stop, step):
                 ^^^^^^^^^^^^^^^^^^^^^^^^
    ValueError: range() arg 3 must not be zero

I'm open to a more structural change, but I'm new to Klipper and this was preventing me from getting going; I don't know what would be more appropriate than this quick patch.


Thank you for crowsnest, it's wonderful to see video showing up in Mainsail for the first time 🙂 