### PR TITLE
refactor: refactor apt sources installation

### DIFF
--- a/tools/libs/manage_apps.sh
+++ b/tools/libs/manage_apps.sh
@@ -96,6 +96,7 @@ install_apt_sources() {
     version_id=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | cut -d'"' -f2)
     variant="generic"
     apt_url="https://apt.mainsail.xyz"
+    apt_source="/etc/apt/sources.list.d/mainsail.${src_ext}"
 
     if [[ "$(is_raspios)" = "1" || "$(is_dietpi)" = "1" ]]; then
         variant="rpi"
@@ -110,10 +111,14 @@ install_apt_sources() {
         key_path="/etc/apt/keyrings/mainsail.asc"
     fi
 
-    if curl -s --compressed --fail -o "/etc/apt/sources.list.d/mainsail.${src_ext}" "${apt_url}/mainsail-${id}-${version_id}-${variant}.${src_ext}" &&
+    if curl -s --compressed --fail -o "${apt_source}" "${apt_url}/mainsail-${id}-${version_id}-${variant}.${src_ext}" &&
     curl -s --compressed --fail -o "${key_path}" "${apt_url}/mainsail.gpg.key"; then
         echo "1"
     else
+        rm -rf "${apt_source}" "${key_path}"
+        msg "Warning: Either we do not provide an apt source for your OS or the download of some component failed."
+        msg "Compiling ustreamer locally!"
+        msg "Please check out the docs at ... for more informations on supported OS."
         echo "0"
     fi
 }

--- a/tools/libs/manage_apps.sh
+++ b/tools/libs/manage_apps.sh
@@ -95,20 +95,20 @@ install_apt_sources() {
     id=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | cut -d'"' -f2)
     version_id=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | cut -d'"' -f2)
     variant="generic"
-    apt_url="https://apt.mainsail.xyz"
-    apt_source="/etc/apt/sources.list.d/mainsail.${src_ext}"
 
     if [[ "$(is_raspios)" = "1" || "$(is_dietpi)" = "1" ]]; then
         variant="rpi"
         id="debian"
     fi
 
+    src_ext="sources"
+    key_path="/etc/apt/keyrings/mainsail.asc"
+    apt_url="https://apt.mainsail.xyz"
+    apt_source="/etc/apt/sources.list.d/mainsail.${src_ext}"
+
     if [[ "${id}" = "debian" ]] && [[ "${version_id}" = "11" ]]; then
         src_ext="list"
         key_path="/etc/apt/trusted.gpg.d/mainsail.asc"
-    else
-        src_ext="sources"
-        key_path="/etc/apt/keyrings/mainsail.asc"
     fi
 
     if curl -s --compressed --fail -o "${apt_source}" "${apt_url}/mainsail-${id}-${version_id}-${variant}.${src_ext}" &&

--- a/tools/libs/manage_apps.sh
+++ b/tools/libs/manage_apps.sh
@@ -110,8 +110,8 @@ install_apt_sources() {
         key_path="/etc/apt/keyrings/mainsail.asc"
     fi
 
-    if curl -s --compressed --fail -o "/etc/apt/sources.list.d/mainsail.${src_ext}" "${apt_url}/mainsail-${id}-${version_id}-${variant}.${src_ext}"; then
-        curl -s --compressed -o "${key_path}" "${apt_url}/mainsail.gpg.key"
+    if curl -s --compressed --fail -o "/etc/apt/sources.list.d/mainsail.${src_ext}" "${apt_url}/mainsail-${id}-${version_id}-${variant}.${src_ext}" &&
+    curl -s --compressed --fail -o "${key_path}" "${apt_url}/mainsail.gpg.key"; then
         echo "1"
     else
         echo "0"

--- a/tools/libs/manage_apps.sh
+++ b/tools/libs/manage_apps.sh
@@ -103,13 +103,14 @@ install_apt_sources() {
 
     src_ext="sources"
     key_path="/etc/apt/keyrings/mainsail.asc"
-    apt_url="https://apt.mainsail.xyz"
-    apt_source="/etc/apt/sources.list.d/mainsail.${src_ext}"
 
     if [[ "${id}" = "debian" ]] && [[ "${version_id}" = "11" ]]; then
         src_ext="list"
         key_path="/etc/apt/trusted.gpg.d/mainsail.asc"
     fi
+
+    apt_url="https://apt.mainsail.xyz"
+    apt_source="/etc/apt/sources.list.d/mainsail.${src_ext}"
 
     if curl -s --compressed --fail -o "${apt_source}" "${apt_url}/mainsail-${id}-${version_id}-${variant}.${src_ext}" &&
     curl -s --compressed --fail -o "${key_path}" "${apt_url}/mainsail.gpg.key"; then

--- a/tools/libs/manage_apps.sh
+++ b/tools/libs/manage_apps.sh
@@ -107,7 +107,7 @@ install_apt_sources() {
         key_path="/etc/apt/trusted.gpg.d/mainsail.asc"
     else
         src_ext="sources"
-        key_path="/usr/share/keyrings/mainsail.asc"
+        key_path="/etc/apt/keyrings/mainsail.asc"
     fi
 
     if curl -s --compressed --fail -o "/etc/apt/sources.list.d/mainsail.${src_ext}" "${apt_url}/mainsail-${id}-${version_id}-${variant}.${src_ext}"; then

--- a/tools/libs/manage_apps.sh
+++ b/tools/libs/manage_apps.sh
@@ -116,9 +116,9 @@ install_apt_sources() {
         echo "1"
     else
         rm -rf "${apt_source}" "${key_path}"
-        msg "Warning: Either we do not provide an apt source for your OS or the download of some component failed."
+        msg "Warning: Either we do not provide an APT source for your OS or the download of some component failed."
         msg "Compiling ustreamer locally!"
-        msg "Please check out the docs at ... for more informations on supported OS."
+        msg "Please check out the docs at https://docs.mainsail.xyz/crowsnest/faq/apt/ for more informations on the APT repository."
         echo "0"
     fi
 }

--- a/tools/libs/manage_apps.sh
+++ b/tools/libs/manage_apps.sh
@@ -90,11 +90,12 @@ build_ustreamer() {
 }
 
 install_apt_sources() {
-    local id version_id
+    local id version_id variant apt_url src_ext key_path
 
     id=$(grep '^ID=' /etc/os-release | cut -d'=' -f2 | cut -d'"' -f2)
     version_id=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | cut -d'"' -f2)
     variant="generic"
+    apt_url="https://apt.mainsail.xyz"
 
     if [[ "$(is_raspios)" = "1" || "$(is_dietpi)" = "1" ]]; then
         variant="rpi"
@@ -102,16 +103,18 @@ install_apt_sources() {
     fi
 
     if [[ "${id}" = "debian" ]] && [[ "${version_id}" = "11" ]]; then
-        curl -s --compressed "https://apt.mainsail.xyz/mainsail.gpg.key" | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/mainsail.gpg > /dev/null
-        curl -s --compressed --fail -o /etc/apt/sources.list.d/mainsail.list "https://apt.mainsail.xyz/mainsail-${id}-${version_id}-${variant}.list"
+        src_ext="list"
+        key_path="/etc/apt/trusted.gpg.d/mainsail.asc"
+    else
+        src_ext="sources"
+        key_path="/usr/share/keyrings/mainsail.asc"
+    fi
+
+    if curl -s --compressed --fail -o "/etc/apt/sources.list.d/mainsail.${src_ext}" "${apt_url}/mainsail-${id}-${version_id}-${variant}.${src_ext}"; then
+        curl -s --compressed -o "${key_path}" "${apt_url}/mainsail.gpg.key"
         echo "1"
     else
-        if curl -s --compressed --fail -o /etc/apt/sources.list.d/mainsail.sources "https://apt.mainsail.xyz/mainsail-${id}-${version_id}-${variant}.sources"; then
-            curl -s --compressed "https://apt.mainsail.xyz/mainsail.gpg.key" | gpg --dearmor | sudo tee /usr/share/keyrings/mainsail.gpg > /dev/null
-            echo "1"
-        else
-            echo "0"
-        fi
+        echo "0"
     fi
 }
 


### PR DESCRIPTION
`gpg` is not a default package on Debian systems therefore the key installation fails for these systems.
Using `.asc` as the file extension for the key removes the necessity for `gpg` as `apt` will read the ASCII-armored key directly.
This also needs an adjustment in https://github.com/mainsail-crew/apt.mainsail.xyz to change the path to `.asc` in the `.source` files.

This PR also improves the Code quality of the `install_apt_sources` function.