### PR TITLE
Fix install_apt_sources failure detection

### DIFF
--- a/tools/libs/manage_apps.sh
+++ b/tools/libs/manage_apps.sh
@@ -117,9 +117,6 @@ install_apt_sources() {
         echo "1"
     else
         rm -rf "${apt_source}" "${key_path}"
-        msg "Warning: Either we do not provide an APT source for your OS or the download of some component failed."
-        msg "Compiling ustreamer locally!"
-        msg "Please check out the docs at https://docs.mainsail.xyz/crowsnest/faq/apt/ for more informations on the APT repository."
         echo "0"
     fi
 }
@@ -153,7 +150,8 @@ install_venv() {
 install_apps() {
     msg "Setup Mainsail apt repository ..."
     if [[ "$(install_apt_sources)" = "0" ]]; then
-        msg "We do not support your Distro with the Mainsail apt repository."
+        msg "Warning: Either we do not provide an APT source for your OS or the download of some component failed."
+        msg "Please check out the docs at https://docs.mainsail.xyz/crowsnest/faq/apt/ for more informations on the APT repository."
         msg "Trying to install ustreamer manually."
         msg "Installing build dependencies ..."
         apt-get --yes --no-install-recommends install "${PKGLIST_USTREAMER[@]}" || return 1


### PR DESCRIPTION
msg output going to stdout meant the = "0" check failed to appropriately detect failure to download the sources file (e.g. running on debian testing where VERSION_ID doesn't exist). msg output also was hidden from user visible output.

with this change return codes are unambiguous to test, and all msg output properly makes it to the user visible stdout