### PR TITLE
fix: fix typing error for Debian Bullseye (python 3.9)

### DIFF
--- a/crowsnest/v4l2/ctl.py
+++ b/crowsnest/v4l2/ctl.py
@@ -9,14 +9,14 @@
 
 import copy
 import os
-from typing import Optional
+from typing import Optional, Union
 
 from . import constants, raw, utils
 
 dev_ctls: dict[str, dict[str, dict[str, (raw.v4l2_ext_control, str)]]] = {}
 
 
-def parse_qc(fd: int, qc: raw.v4l2_query_ext_ctrl) -> dict | None:
+def parse_qc(fd: int, qc: raw.v4l2_query_ext_ctrl) -> Union[dict, None]:
     """
     Parses the query control to an easy to use dictionary
     """
@@ -62,7 +62,7 @@ def parse_qc(fd: int, qc: raw.v4l2_query_ext_ctrl) -> dict | None:
     return controls
 
 
-def parse_qc_of_path(device_path: str, qc: raw.v4l2_query_ext_ctrl) -> dict | None:
+def parse_qc_of_path(device_path: str, qc: raw.v4l2_query_ext_ctrl) -> Union[dict, None]:
     """
     Parses the query control to an easy to use dictionary
     """


### PR DESCRIPTION
This PR fix a typing issue with Python 3.9 (Debian Bullseye) from the PR #347 .