### PR TITLE
ci: add code check workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,46 @@
+name: Pull Request
+
+on:
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version-file: 'pyproject.toml'
+          cache: 'pip'
+
+      - name: Install Dependencies
+        run: pip install basedpyright
+
+      - name: Run Basedpyright
+        run: basedpyright
+
+  format-check:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run Ruff format check
+        uses: astral-sh/ruff-action@v4.1.0
+        with:
+          args: "format --check"
+
+  lint-check:
+    name: Lint Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run Ruff check
+        uses: astral-sh/ruff-action@v4.1.0
+        with:
+          args: 'check'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,8 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - name: Check out
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -27,7 +28,8 @@ jobs:
     name: Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - name: Check out
+        uses: actions/checkout@v7
 
       - name: Run Ruff format check
         uses: astral-sh/ruff-action@v4.1.0
@@ -38,7 +40,8 @@ jobs:
     name: Lint Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - name: Check out
+        uses: actions/checkout@v7
 
       - name: Run Ruff check
         uses: astral-sh/ruff-action@v4.1.0


### PR DESCRIPTION
This PR adds 3 checks:
1. `ruff check`: checks for linting errors
2. `ruff format --check`: checks formatting
3. `basedpyright`: checks typing

Should be merged after #355 