### PR TITLE
fix: increase strictness on section names

### DIFF
--- a/crowsnest/components/cam.py
+++ b/crowsnest/components/cam.py
@@ -26,6 +26,9 @@ class Cam(Section):
         if name == "":
             logger.log_error(f"Section [{config_section.name}] is missing a name!")
             logger.log_error(f"Expected format: [{self.section_name} camera_name]")
+            self.initialized = False
+            return
+
         super().__init__(name, config_section)
 
     def parse_config_section(

--- a/crowsnest/components/cam.py
+++ b/crowsnest/components/cam.py
@@ -22,6 +22,12 @@ class Cam(Section):
     section_name: str = "cam"
     keyword: str = "cam"
 
+    def __init__(self, name: str, config_section: SectionProxy) -> None:
+        if name == "":
+            logger.log_error(f"Section [{config_section.name}] is missing a name!")
+            logger.log_error(f"Expected format: [{self.section_name} camera_name]")
+        super().__init__(name, config_section)
+
     def parse_config_section(
         self, config_section: SectionProxy, *args, **kwargs
     ) -> None:

--- a/crowsnest/crowsnest.py
+++ b/crowsnest/crowsnest.py
@@ -75,7 +75,7 @@ def _create_section_objects(config: configparser.ConfigParser) -> list:
                 f"Section name of [{section}] has leading or trailing whitespaces!"
             )
             stripped_name = section_name.strip()
-            whitespace = bool(len(stripped_name))
+            whitespace = len(stripped_name) > 0
             logger.log_error(
                 f"Expected: [{section_header}{whitespace * ' '}{section_name.strip()}"
             )

--- a/crowsnest/crowsnest.py
+++ b/crowsnest/crowsnest.py
@@ -97,7 +97,6 @@ async def start_sections(config: configparser.ConfigParser) -> None:
 
             log_prefix = f"[{section}]: "
             section_name = " ".join(section_header[1:])
-
             logger.log_quiet("Parse configuration ...", log_prefix)
             component = utils.load_component(
                 section_keyword, section_name, config[section]

--- a/crowsnest/crowsnest.py
+++ b/crowsnest/crowsnest.py
@@ -69,6 +69,7 @@ def _create_section_objects(config: configparser.ConfigParser) -> list:
 
         log_prefix = f"[{section}]: "
         section_name = " ".join(section_header[1:])
+
         if section_name != section_name.strip():
             logger.log_error(
                 f"Section name of [{section}] has leading or trailing whitespaces!"
@@ -79,6 +80,7 @@ def _create_section_objects(config: configparser.ConfigParser) -> list:
                 f"Expected: [{section_header}{whitespace * ' '}{section_name.strip()}"
             )
             continue
+
         logger.log_quiet("Parse configuration ...", log_prefix)
         component = utils.load_component(
             section_keyword, section_name.strip(), config[section]

--- a/crowsnest/crowsnest.py
+++ b/crowsnest/crowsnest.py
@@ -60,7 +60,7 @@ async def task_watchdog(pending: set[asyncio.Task[int | None]]) -> None:
             log_fn(f"{name} exited with code {exit_code}")
 
 
-def _create_section_components(config: configparser.ConfigParser) -> list:
+def _create_section_objects(config: configparser.ConfigParser) -> list:
     sect_objs: list = []
 
     for section in config.sections():
@@ -107,7 +107,7 @@ async def start_sections(config: configparser.ConfigParser) -> None:
     logger.log_quiet("Try to parse configured Cams / Services...")
 
     try:
-        sect_objs = _create_section_components(config)
+        sect_objs = _create_section_objects(config)
 
         logger.log_quiet("Try to start configured Cams / Services ...")
         if sect_objs:

--- a/crowsnest/crowsnest.py
+++ b/crowsnest/crowsnest.py
@@ -60,8 +60,39 @@ async def task_watchdog(pending: set[asyncio.Task[int | None]]) -> None:
             log_fn(f"{name} exited with code {exit_code}")
 
 
-async def start_sections(config: configparser.ConfigParser) -> None:
+def _create_section_components(config: configparser.ConfigParser) -> list:
     sect_objs: list = []
+
+    for section in config.sections():
+        section_header = section.split(" ")
+        section_keyword = section_header[0]
+
+        log_prefix = f"[{section}]: "
+        section_name = " ".join(section_header[1:])
+        if section_name != section_name.strip():
+            logger.log_error(
+                f"Section name of [{section}] has leading or trailing whitespaces!"
+            )
+            stripped_name = section_name.strip()
+            whitespace = bool(len(stripped_name))
+            logger.log_error(
+                f"Expected: [{section_header}{whitespace * ' '}{section_name.strip()}"
+            )
+            continue
+        logger.log_quiet("Parse configuration ...", log_prefix)
+        component = utils.load_component(
+            section_keyword, section_name.strip(), config[section]
+        )
+        if component is not None and component.initialized:
+            sect_objs.append(component)
+            logger.log_quiet("Configuration looks good. Continue ...", log_prefix)
+        else:
+            logger.log_error("Failed to parse config! Skipping ...", log_prefix)
+
+    return sect_objs
+
+
+async def start_sections(config: configparser.ConfigParser) -> None:
     sect_exec_tasks: set[asyncio.Task[int | None]] = set()
 
     # Catches SIGINT and SIGTERM to exit gracefully and cancel all tasks
@@ -76,32 +107,7 @@ async def start_sections(config: configparser.ConfigParser) -> None:
     logger.log_quiet("Try to parse configured Cams / Services...")
 
     try:
-        for section in config.sections():
-            section_header = section.split(" ")
-            section_object = None
-            section_keyword = section_header[0]
-
-            log_prefix = f"[{section}]: "
-            section_name = " ".join(section_header[1:])
-            if section_name != section_name.strip():
-                logger.log_error(
-                    f"Section name of [{section}] has leading or trailing whitespaces!"
-                )
-                stripped_name = section_name.strip()
-                whitespace = bool(len(stripped_name))
-                logger.log_error(
-                    f"Expected: [{section_header}{whitespace * ' '}{section_name.strip()}"
-                )
-                continue
-            logger.log_quiet("Parse configuration ...", log_prefix)
-            component = utils.load_component(
-                section_keyword, section_name.strip(), config[section]
-            )
-            if component is not None and component.initialized:
-                sect_objs.append(component)
-                logger.log_quiet("Configuration looks good. Continue ...", log_prefix)
-            else:
-                logger.log_error("Failed to parse config! Skipping ...", log_prefix)
+        sect_objs = _create_section_components(config)
 
         logger.log_quiet("Try to start configured Cams / Services ...")
         if sect_objs:

--- a/crowsnest/crowsnest.py
+++ b/crowsnest/crowsnest.py
@@ -83,9 +83,19 @@ async def start_sections(config: configparser.ConfigParser) -> None:
 
             log_prefix = f"[{section}]: "
             section_name = " ".join(section_header[1:])
+            if section_name != section_name.strip():
+                logger.log_error(
+                    f"Section name of [{section}] has leading or trailing whitespaces!"
+                )
+                stripped_name = section_name.strip()
+                whitespace = bool(len(stripped_name))
+                logger.log_error(
+                    f"Expected: [{section_header}{whitespace * ' '}{section_name.strip()}"
+                )
+                continue
             logger.log_quiet("Parse configuration ...", log_prefix)
             component = utils.load_component(
-                section_keyword, section_name, config[section]
+                section_keyword, section_name.strip(), config[section]
             )
             if component is not None and component.initialized:
                 sect_objs.append(component)

--- a/crowsnest/crowsnest.py
+++ b/crowsnest/crowsnest.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import configparser
+import re
 import signal
 import sys
 import time
@@ -24,11 +25,24 @@ from crowsnest.components.crowsnest import Crowsnest
 from crowsnest.components.streamer.streamer import Streamer
 
 
+def _clean_header(config_path):
+    with open(config_path) as config:
+        for line in config:
+            if not line.strip().startswith("["):
+                yield re.sub(
+                    r"\[(.*?)\]",
+                    lambda m: f"[{' '.join(m.group(1).split())}]",
+                    line,
+                )
+            else:
+                yield line
+
+
 def initial_parse_config(
     config_path: str, config: configparser.ConfigParser
 ) -> Crowsnest:
     try:
-        config.read(config_path)
+        config.read_file(_clean_header(config_path))
     except configparser.Error as e:
         logger.log_multiline(e.message, logger.log_error)
         logger.log_error("Failed to parse config! Exiting...")
@@ -60,41 +74,8 @@ async def task_watchdog(pending: set[asyncio.Task[int | None]]) -> None:
             log_fn(f"{name} exited with code {exit_code}")
 
 
-def _create_section_objects(config: configparser.ConfigParser) -> list:
-    sect_objs: list = []
-
-    for section in config.sections():
-        section_header = section.split(" ")
-        section_keyword = section_header[0]
-
-        log_prefix = f"[{section}]: "
-        section_name = " ".join(section_header[1:])
-
-        if section_name != section_name.strip():
-            logger.log_error(
-                f"Section name of [{section}] has leading or trailing whitespaces!"
-            )
-            stripped_name = section_name.strip()
-            whitespace = len(stripped_name) > 0
-            logger.log_error(
-                f"Expected: [{section_header}{whitespace * ' '}{section_name.strip()}"
-            )
-            continue
-
-        logger.log_quiet("Parse configuration ...", log_prefix)
-        component = utils.load_component(
-            section_keyword, section_name.strip(), config[section]
-        )
-        if component is not None and component.initialized:
-            sect_objs.append(component)
-            logger.log_quiet("Configuration looks good. Continue ...", log_prefix)
-        else:
-            logger.log_error("Failed to parse config! Skipping ...", log_prefix)
-
-    return sect_objs
-
-
 async def start_sections(config: configparser.ConfigParser) -> None:
+    sect_objs: list = []
     sect_exec_tasks: set[asyncio.Task[int | None]] = set()
 
     # Catches SIGINT and SIGTERM to exit gracefully and cancel all tasks
@@ -109,7 +90,23 @@ async def start_sections(config: configparser.ConfigParser) -> None:
     logger.log_quiet("Try to parse configured Cams / Services...")
 
     try:
-        sect_objs = _create_section_objects(config)
+        for section in config.sections():
+            section_header = section.split(" ")
+            section_object = None
+            section_keyword = section_header[0]
+
+            log_prefix = f"[{section}]: "
+            section_name = " ".join(section_header[1:])
+
+            logger.log_quiet("Parse configuration ...", log_prefix)
+            component = utils.load_component(
+                section_keyword, section_name, config[section]
+            )
+            if component is not None and component.initialized:
+                sect_objs.append(component)
+                logger.log_quiet("Configuration looks good. Continue ...", log_prefix)
+            else:
+                logger.log_error("Failed to parse config! Skipping ...", log_prefix)
 
         logger.log_quiet("Try to start configured Cams / Services ...")
         if sect_objs:
@@ -173,6 +170,7 @@ async def main() -> None:
             "loglevel": utils.log_level_converter,
             "resolution": utils.resolution_converter,
         },
+        strict=False,
     )
 
     parser.add_argument(

--- a/crowsnest/crowsnest.py
+++ b/crowsnest/crowsnest.py
@@ -28,7 +28,7 @@ from crowsnest.components.streamer.streamer import Streamer
 def _clean_header(config_path):
     with open(config_path) as config:
         for line in config:
-            if not line.strip().startswith("["):
+            if line.strip().startswith("["):
                 yield re.sub(
                     r"\[(.*?)\]",
                     lambda m: f"[{' '.join(m.group(1).split())}]",


### PR DESCRIPTION
Previously section names were able to contain leading and trailing whitespaces, as well as omit a name completely or add multiple whitespaces in the name.

This ignores leading, trailing and multiple whitespaces, as well as allows for duplicate sections getting merged.
E.g. the following config
```ini
[   cam    1   2   ]
port: 8080
max_fps: 15

[cam 1 2]
port: 8081
```
now becomes
```ini
[cam 1 2]
port: 8081
max_fps: 15
```

This will also log an error if a `cam` section has no name, e.g.
```ini
[cam]
```
will now log an error.