### PR TITLE
fix(uvc): detect capture interfaces beyond index0

### DIFF
--- a/crowsnest/camera/types/uvc.py
+++ b/crowsnest/camera/types/uvc.py
@@ -98,8 +98,11 @@ class UVC(camera.Camera[dict[str, dict[str, list[str]]]]):
                 return avail_uvc
             for file in os.listdir(search_path):
                 dev_path = os.path.join(search_path, file)
-                if os.path.islink(dev_path) and dev_path.endswith("index0"):
-                    avail_uvc[os.path.realpath(dev_path)] = dev_path
+                if not os.path.islink(dev_path):
+                    continue
+                real_path = os.path.realpath(dev_path)
+                if v4l2.ctl.get_formats(real_path):
+                    avail_uvc[real_path] = dev_path
             return avail_uvc
 
         avail_by_id = get_avail_uvc("/dev/v4l/by-id/")


### PR DESCRIPTION
Fixes #363.

## What changed

UVC discovery now registers symlinked V4L2 nodes that enumerate capture formats instead of assuming the usable interface always ends in `index0`.

This supports composite cameras such as Creality CAM, where index0 exposes H264/HEVC and index2 exposes MJPEG, while excluding metadata-only nodes with no capture formats.

## Validation

- Reproduced with Creality CAM `1d6c:0103`
- Confirmed MJPEG capture from video-index2 using `v4l2-ctl`
- Confirmed updated crowsnest starts ustreamer and streams from video-index2 on the physical hardware
- `python -m compileall -q crowsnest`
- `ruff format --check`
- `ruff check`
- `basedpyright`

## AI disclosure

This PR was prepared with assistance from OpenAI Codex. I reproduced and tested the issue on the physical Creality CAM hardware, reviewed the proposed change, and verified the resulting service behavior.