### PR TITLE
fix(uvc): handle controls without default values

### DIFF
--- a/crowsnest/camera/types/uvc.py
+++ b/crowsnest/camera/types/uvc.py
@@ -69,7 +69,8 @@ class UVC(camera.Camera[dict[str, dict[str, list[str]]]]):
                 line += max(0, 35 - len(line)) * " " + ":"
                 if data["type"] in ("int",):
                     line += f" min={data['min']} max={data['max']} step={data['step']}"
-                line += f" default={data['default']}"
+                if "default" in data:
+                    line += f" default={data['default']}"
                 line += f" value={self.get_current_control_value(control)}"
                 if "flags" in data:
                     line += f" flags={data['flags']}"


### PR DESCRIPTION
## Problem

Some UVC devices expose V4L2 controls without a default field. Crowsnest currently indexes the field unconditionally while logging supported controls, causing startup to fail with KeyError before the configured streamer starts.

## Fix

Only log the default value when the parsed control provides one. Controls without a default still log their current value and do not prevent startup.

## Validation

Tested with a webcam exposing:
- region_of_interest_rectangle
- region_of_interest_auto_ctrls

Verified that Crowsnest starts and the camera stream returns HTTP 200 with MJPEG data.